### PR TITLE
Update 2014-06-16-dots.md

### DIFF
--- a/_posts/2014-06-16-dots.md
+++ b/_posts/2014-06-16-dots.md
@@ -60,9 +60,9 @@ update        Update dots
 
 ## Links
 
-* [Source Code (GitHub)](https://github.com/bpkg/github);
+* [Source Code (GitHub)](https://github.com/bpkg/dots);
 * Author: [Matthew Mueller](https://github.com/MatthewMueller);
 * Packager: [Joseph Werle](https://github.com/jwerle);
-* Logo by [Piotrek Chuchla](Piotrek Chuchla)
+* Logo by [Piotrek Chuchla](http://www.thenounproject.com/pchuchla/)
 
 


### PR DESCRIPTION
Source Code linked to `bpkg/github` instead of `bpkg/dots` and logo artist's site is `http://www.thenounproject.com/pchuchla/` (according to `README.md`)
