### PR TITLE
Fix instructions for installing shpec

### DIFF
--- a/_posts/2015-05-05-shpec.md
+++ b/_posts/2015-05-05-shpec.md
@@ -86,7 +86,7 @@ end
 ## Installation
 You can either install with bpkg
 {% highlight bash %}
-$ bpkg install -g shpec
+$ bpkg install rylnd/shpec
 {% endhighlight %}
 or with curl
 {% highlight bash %}


### PR DESCRIPTION
* Use the user/org-prefixed package name
* We don't need the -g, that's part of shpec's configuration