### PR TITLE
Updated index link for raw install code

### DIFF
--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ Just paste the following on your shell:
 $ curl -sLo- http://get.bpkg.io | bash
 {% endhighlight %}
 
-If you want to see what's inside it, [access it directly](http://get.bpkg.io) or [check it out on the repository](https://raw.githubusercontent.com/bpkg/bpkg/master/install.sh).
+If you want to see what's inside it, [access it directly](http://get.bpkg.io) or [check it out on the repository](https://github.com/bpkg/bpkg/blob/master/setup.sh).
 
 ### 2. clibs
 

--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ Just paste the following on your shell:
 $ curl -sLo- http://get.bpkg.io | bash
 {% endhighlight %}
 
-If you want to see what's inside it, [access it directly](http://get.bpkg.io) or [check it out on the repository](https://github.com/bpkg/bpkg/blob/master/setup.sh).
+If you want to see what's inside it, [access it directly](http://get.bpkg.io) or [check it out on the repository](https://raw.githubusercontent.com/bpkg/bpkg/master/setup.sh).
 
 ### 2. clibs
 


### PR DESCRIPTION
I noticed today that the link on the homepage to the raw install code had changed and was getting a not found. Hope this helps!

![changed-link-image](https://monosnap.com/file/pyOF7SeMvCS0UW8vwIUhkUoucp3ZOT.png)