### PR TITLE
Fix production_url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,7 +49,7 @@ exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
 # Else if you are pushing to username.github.io, replace with your username.
 # Finally if you are pushing to a GitHub project page, include the project name at the end.
 #
-production_url : http://username.github.io
+production_url : http://bpkg.github.io
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Jekyll-Bootstrap specific configurations


### PR DESCRIPTION
I noticed that items in the feed are incorrectly linked to http://username.github.io/pkg/chap (for example). I think this should fix it.