### PR TITLE
Fix typo on guidelines page

### DIFF
--- a/guidelines/index.md
+++ b/guidelines/index.md
@@ -12,7 +12,7 @@ Here we lay down some info on the structure of a package.
 ## bpkg.json
 
 Every package must have a file called `bpkg.json`; it specifies package metadata on the [JSON format][json].
-(For legacy reasons, this file may also be called `pacakge.json`).
+(For legacy reasons, this file may also be called `package.json`).
 
 Here's an example of a well-formed `bpkg.json`:
 


### PR DESCRIPTION
A small typo on the [guidelines](http://bpkg.sh/guidelines/) page (`pacakge.json`)