### PR TITLE
Add records.sh logging library package

### DIFF
--- a/_posts/2023-06-13-recordssh.md
+++ b/_posts/2023-06-13-recordssh.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title: "records.sh"
+description: "A small logging library for bash. Supports `cli`, `json`, `logfmt`, and custom formats. Integrates with journald and Github actions."
+category: bash
+tags: [library, logging]
+---
+
+See https://github.com/orbit-online/records.sh for the full README and more
+advanced use-cases.
+
+## Usage
+
+Source the script with `source "records.sh"` and log messages with the
+lowercased loglevel as the function name:
+
+```
+debug 'Starting up.'
+verbose 'Startup completed'
+info 'Hello world!'
+warning 'Careful!'
+error 'Oh no!'
+```
+
+The method signature of the logging functions mimic that of `printf`:
+`info FORMAT [ARGS...]`. Which means you can format variables.
+
+```
+$ var=0x1f
+$ info "The decimal version of %s is %d" "$var" "$var"
+example.sh: The decimal version of 0x1f is 31
+```
+
+All log messages are output to stderr. If you want to log something to stdout
+simply run e.g. `info 'message' 2>&1`.
+
+## Links
+
+- [Source Code (GitHub)][https://github.com/orbit-online/records.sh]
+- [Author: Orbit Online A/S (Anders Ingemann)](https://orbit.online)
+
+{% include JB/setup %}


### PR DESCRIPTION
Heyo :wave:  

Here's a submission for a logging library.  
At our company we use a version of this library for quite a few scripts, so it's somewhat battle-tested. I've had to adjust a few things in order to make it publishable though, so it's not the exact same code (hence the 0.9.0 version in the repo).

Regardless, I thought it would make a nice addition to the index. Note that I have added the `logging` tag, which... I *think* makes sense? Else just let me know and I'll remove it.