### PR TITLE
Add protobuf-parser

### DIFF
--- a/_posts/2023-07-07-protobuf-parser.md
+++ b/_posts/2023-07-07-protobuf-parser.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "protobuf parser"
+title: "protobuf-parser"
 description: "A Protobuf parser, encoder and decoder in Bash."
 category: bash
 tags: [library, lib, bash, parser, protobuf]

--- a/_posts/2023-07-07-protobuf-parser.md
+++ b/_posts/2023-07-07-protobuf-parser.md
@@ -4,8 +4,6 @@ title: "protobuf-parser"
 description: "A Protobuf parser, encoder and decoder in Bash."
 category: bash
 tags: [library, lib, bash, parser, protobuf]
-source code link: https://github.com/lafkpages/protobuf-parser-bash
-author: LuisAFK <soy.lafk+pbfbpkg@gmail.com>
 ---
 
 {% include JB/setup %}

--- a/_posts/2023-07-07-protobuf-parser.md
+++ b/_posts/2023-07-07-protobuf-parser.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "protobuf-parser"
+title: "lafkpages/protobuf-parser-bash"
 description: "A Protobuf parser, encoder and decoder in Bash."
 category: bash
 tags: [library, lib, bash, parser, protobuf]

--- a/_posts/2023-07-07-protobuf-parser.md
+++ b/_posts/2023-07-07-protobuf-parser.md
@@ -1,0 +1,45 @@
+---
+layout: post
+title: "protobuf parser"
+description: "A Protobuf parser, encoder and decoder in Bash."
+category: bash
+tags: [library, lib, bash, parser, protobuf]
+source code link: https://github.com/lafkpages/protobuf-parser-bash
+author: LuisAFK <soy.lafk+pbfbpkg@gmail.com>
+---
+
+{% include JB/setup %}
+
+# protobuf-parser
+
+A Protobuf parser, encoder and decoder in Bash.
+
+## Install
+
+You'll need `protoc` for running some of the test scripts, but of course
+you can use the library without it.
+
+To install this package, run:
+
+```bash
+bpkg install lafkpages/protobuf-parser-bash
+```
+
+## Usage
+
+Then, to lex and parse a `.proto` file, run:
+
+```bash
+./src/main.sh <path-to-proto-file>
+```
+
+You can try it with the [`test/example.proto`](#test/example.proto) file:
+
+```bash
+./src/main.sh test/example.proto
+```
+
+## Links
+
+- [Source code (GitHub)](https://github.com/lafkpages/protobuf-parser-bash)
+- [Author: LuisAFK](https://github.com/lafkpages)


### PR DESCRIPTION
A Bash library for parsing Protobuf files and `protoc` output.

Note that this is still a work-in-progress, but I thought I'd start the PR early.

Also please let me know if I did something wrong.